### PR TITLE
Ios10 autolayout fix

### DIFF
--- a/Fabulous.podspec
+++ b/Fabulous.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'Fabulous'
-  s.version       = '1.0.0'
+  s.version       = '1.0.1'
   s.summary       = 'A material-inspired floating action button.'
   s.description   = <<-DESC
                     A material-inspired floating action button with a little Human Interface flair.

--- a/Fabulous.xcodeproj/project.pbxproj
+++ b/Fabulous.xcodeproj/project.pbxproj
@@ -382,6 +382,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Fabulous/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -409,6 +410,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Fabulous/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Fabulous/Sources/Public/FabulousViewController.swift
+++ b/Fabulous/Sources/Public/FabulousViewController.swift
@@ -233,7 +233,7 @@ import UIKit
             bottomAnchor = view.safeAreaLayoutGuide.bottomAnchor
             rightAnchor = view.safeAreaLayoutGuide.rightAnchor
         } else {
-            bottomAnchor = bottomLayoutGuide.topAnchor
+            bottomAnchor = view.bottomAnchor
             rightAnchor = view.rightAnchor
         }
 

--- a/FabulousDemo/FabulousDemo.xcodeproj/project.pbxproj
+++ b/FabulousDemo/FabulousDemo.xcodeproj/project.pbxproj
@@ -15,6 +15,16 @@
 		94BC614420F922F30073D3E2 /* Fabulous.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 94BC614220F922F30073D3E2 /* Fabulous.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		B518A7AA210B5CFA0018E93C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B518A7A6210B5CFA0018E93C /* Fabulous.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 947A47B020EA8B19005A353D;
+			remoteInfo = Fabulous;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		94BC614520F922F40073D3E2 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -37,6 +47,7 @@
 		94BC613A20F922660073D3E2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		94BC613C20F922660073D3E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		94BC614220F922F30073D3E2 /* Fabulous.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Fabulous.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B518A7A6210B5CFA0018E93C /* Fabulous.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Fabulous.xcodeproj; path = ../Fabulous.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +68,7 @@
 				94BC614220F922F30073D3E2 /* Fabulous.framework */,
 				94BC612F20F922640073D3E2 /* FabulousDemo */,
 				94BC612E20F922640073D3E2 /* Products */,
+				B518A7A6210B5CFA0018E93C /* Fabulous.xcodeproj */,
 			);
 			sourceTree = "<group>";
 		};
@@ -78,6 +90,14 @@
 				94BC613C20F922660073D3E2 /* Info.plist */,
 			);
 			path = FabulousDemo;
+			sourceTree = "<group>";
+		};
+		B518A7A7210B5CFA0018E93C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B518A7AB210B5CFA0018E93C /* Fabulous.framework */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -127,12 +147,28 @@
 			mainGroup = 94BC612420F922640073D3E2;
 			productRefGroup = 94BC612E20F922640073D3E2 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = B518A7A7210B5CFA0018E93C /* Products */;
+					ProjectRef = B518A7A6210B5CFA0018E93C /* Fabulous.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				94BC612C20F922640073D3E2 /* FabulousDemo */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		B518A7AB210B5CFA0018E93C /* Fabulous.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Fabulous.framework;
+			remoteRef = B518A7AA210B5CFA0018E93C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		94BC612B20F922640073D3E2 /* Resources */ = {
@@ -291,6 +327,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 75Y586SA36;
 				INFOPLIST_FILE = FabulousDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -309,6 +346,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 75Y586SA36;
 				INFOPLIST_FILE = FabulousDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/FabulousDemo/FabulousDemo/AppDelegate.swift
+++ b/FabulousDemo/FabulousDemo/AppDelegate.swift
@@ -16,10 +16,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let window = UIWindow(frame: UIScreen.main.bounds)
         let navigationController = UINavigationController(rootViewController: ViewController())
-        navigationController.navigationBar.prefersLargeTitles = true
-        navigationController.navigationBar.largeTitleTextAttributes = [
-            .foregroundColor: UIColor(red: 0.3098, green: 0.6235, blue: 0.2745, alpha: 1)
-        ]
+        if #available(iOS 11.0, *) {
+            navigationController.navigationBar.prefersLargeTitles = true
+            navigationController.navigationBar.largeTitleTextAttributes = [
+                .foregroundColor: UIColor(red: 0.3098, green: 0.6235, blue: 0.2745, alpha: 1)
+            ]
+        }
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
 
@@ -29,4 +31,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
+
 


### PR DESCRIPTION
- Sets projects to build for iOS 10.3
- In iOS 10 no longer use `bottomLayoutGuide.topAnchor` as it does not exist in the view hierarchy according to AutoLayout and causes a crash, using `view.bottomAnchor` instead which seems to work fine.